### PR TITLE
Fixed year auto scroll

### DIFF
--- a/src/Years/index.js
+++ b/src/Years/index.js
@@ -146,6 +146,8 @@ export default class Years extends Component {
       ? years.length * rowHeight
       : height + 50;
 
+    const scrollOffset =  years.length * rowHeight < height + 50 || selectedYearIndex === -1 ? 0 : heights.slice(0, selectedYearIndex).reduce((acc, val) => acc + val, 0) - (containerHeight / 2) + 50;
+    console.log('scrollOffset:', scrollOffset, 'selectedYearIndex:', selectedYearIndex);
     return (
       <div
         className={styles.root}
@@ -159,8 +161,7 @@ export default class Years extends Component {
           itemCount={years.length}
           estimatedItemSize={rowHeight}
           itemSize={(index) => heights[index]}
-          scrollToIndex={selectedYearIndex !== -1 ? selectedYearIndex : null}
-          scrollToAlignment='center'
+          scrollOffset={scrollOffset}
           renderItem={({index, style}) => {
             const year = years[index];
             const isActive = index === selectedYearIndex;

--- a/src/Years/index.js
+++ b/src/Years/index.js
@@ -147,7 +147,7 @@ export default class Years extends Component {
       : height + 50;
 
     const scrollOffset =  years.length * rowHeight < height + 50 || selectedYearIndex === -1 ? 0 : heights.slice(0, selectedYearIndex).reduce((acc, val) => acc + val, 0) - (containerHeight / 2) + 50;
-    console.log('scrollOffset:', scrollOffset, 'selectedYearIndex:', selectedYearIndex);
+
     return (
       <div
         className={styles.root}

--- a/src/Years/index.js
+++ b/src/Years/index.js
@@ -142,11 +142,16 @@ export default class Years extends Component {
       ? rowHeight + SPACING
       : rowHeight
     );
-    const containerHeight = years.length * rowHeight < height + 50
+    const isYearLess = years.length * rowHeight < height + 50;
+    const containerHeight = isYearLess
       ? years.length * rowHeight
       : height + 50;
 
-    const scrollOffset =  years.length * rowHeight < height + 50 || selectedYearIndex === -1 ? 0 : heights.slice(0, selectedYearIndex).reduce((acc, val) => acc + val, 0) - (containerHeight / 2) + 50;
+    let scrollOffset = 0;
+    if (!isYearLess && selectedYearIndex !== -1) {
+        const top = heights.slice(0, selectedYearIndex).reduce((acc, val) => acc + val, 0);
+        scrollOffset = top - (containerHeight / 2) + 50;
+    }
 
     return (
       <div


### PR DESCRIPTION
The Infinite calendar story work fine if selecting month range (Video: [inifiniteCalendar.zip](https://github.com/appannie/react-infinite-calendar/files/1978840/inifiniteCalendar.zip)), 

but it always auto scroll to start date  after integrating to picker component in aa-react (Video: [autoScroll.zip](https://github.com/appannie/react-infinite-calendar/files/1978841/autoScroll.zip)).

This PR fixed auto scroll issue.

Ref Doc: 
react tiny virtual list: https://github.com/clauderic/react-tiny-virtual-list