### PR TITLE
Remove scrollbar when we have less years to display

### DIFF
--- a/src/.stories/index.js
+++ b/src/.stories/index.js
@@ -84,6 +84,24 @@ storiesOf('Higher Order Components', module)
       Component={withMonthRange(Calendar)}
     />
   ))
+  .add('Month Range selection with 5 selectable months', () => (
+    <InfiniteCalendar
+      selected={{
+        start: subMonths(new Date(), 1),
+        end: addMonths(new Date(), 1),
+      }}
+      display={'years'}
+      displayOptions={{
+        showHeader: false,
+        hideYearsOnSelect: false,
+      }}
+      min={subMonths(new Date(), 2)}
+      max={addMonths(new Date(), 2)}
+      minDate={subMonths(new Date(), 2)}
+      maxDate={addMonths(new Date(), 2)}
+      Component={withMonthRange(Calendar)}
+    />
+  ))
   .add('Multiple date selection', () => {
     return (
       <InfiniteCalendar

--- a/src/Years/Years.scss
+++ b/src/Years/Years.scss
@@ -166,6 +166,7 @@ $cellSize: 44px;
   }
   &.last {
     padding-bottom: $spacing;
+    border-bottom: none;
   }
 }
 

--- a/src/Years/index.js
+++ b/src/Years/index.js
@@ -144,7 +144,7 @@ export default class Years extends Component {
     );
     const isYearLess = years.length * rowHeight < height + 50;
     const containerHeight = isYearLess
-      ? years.length * rowHeight
+      ? years.length * rowHeight + 2 * SPACING
       : height + 50;
 
     let scrollOffset = 0;

--- a/styles.css
+++ b/styles.css
@@ -576,7 +576,8 @@
   .Cal__Years__year.Cal__Years__first {
     padding-top: 40px; }
   .Cal__Years__year.Cal__Years__last {
-    padding-bottom: 40px; }
+    padding-bottom: 40px;
+    border-bottom: none; }
 
 /*
  * Range selection styles


### PR DESCRIPTION
In monthly view, remove scrollbar when the total height is less than the height we set on the calendar.

Also removed the bottom border for the last year.

After:

![image](https://user-images.githubusercontent.com/12229459/69223234-f4119300-0bb5-11ea-8f9e-67020e1408fe.png)

Before:

![image](https://user-images.githubusercontent.com/12229459/69223362-2f13c680-0bb6-11ea-9a6b-8e5fdd53e492.png)

It should look like this after it's published and integrated into our report.

![image](https://user-images.githubusercontent.com/12229459/69223528-7ac67000-0bb6-11ea-8ce9-2b5d87a75de1.png)


