### PR TITLE
Add initial scroll date to auto scroll to date when click date shortcuts

### DIFF
--- a/src/Calendar/index.js
+++ b/src/Calendar/index.js
@@ -301,6 +301,7 @@ export default class Calendar extends Component {
       HeaderComponent,
       rowHeight,
       scrollDate,
+      initialScrollDate,
       selected,
       tabIndex,
       width,
@@ -393,6 +394,7 @@ export default class Calendar extends Component {
               scrollDate={scrollDate}
               showOverlay={showOverlay}
               width={width}
+              initialScrollDate={initialScrollDate}
             />
           </div>
           {display === 'years' && (

--- a/src/MonthList/index.js
+++ b/src/MonthList/index.js
@@ -85,6 +85,17 @@ export default class MonthList extends Component {
     }
   }
 
+  componentDidUpdate(prevProps) {
+    if (
+      this.props.initialScrollDate != null &&
+      this.props.initialScrollDate !== prevProps.initialScrollDate
+    ) {
+      this.setState({
+        scrollTop: this.getDateOffset(this.props.initialScrollDate),
+      });
+    }
+  }
+
   getDateOffset(date) {
     const {
       min,


### PR DESCRIPTION
Add `initialScrollDate` prop to support the auto scroll to highlighted date area when click date shortcuts.

We'll set `initialScrollDate` as `undefined` when we do selection inside the calendar. When we click the shortcut we'll set the start date as the `initialScrollDate`.