### PR TITLE
Prevent selection of dates that are out of valid range

### DIFF
--- a/src/Calendar/index.js
+++ b/src/Calendar/index.js
@@ -1,7 +1,13 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { debounce, emptyFn, range, ScrollSpeed } from '../utils';
+import {
+  debounce,
+  emptyFn,
+  range,
+  ScrollSpeed,
+  getValidSelectedRange,
+} from '../utils';
 import { defaultProps } from 'recompose';
 import defaultDisplayOptions from '../utils/defaultDisplayOptions';
 import defaultLocale from '../utils/defaultLocale';
@@ -306,6 +312,10 @@ export default class Calendar extends Component {
       tabIndex,
       width,
       YearsComponent,
+      minDate,
+      maxDate,
+      min,
+      max,
     } = this.props;
     const {
       hideYearsOnSelect,
@@ -323,6 +333,11 @@ export default class Calendar extends Component {
     const locale = this.getLocale();
     const theme = this.getTheme();
     const today = (this.today = startOfDay(new Date()));
+    const validSelection = getValidSelectedRange(
+      selected,
+      minDate || min,
+      maxDate || max
+    );
 
     return (
       <div
@@ -339,7 +354,7 @@ export default class Calendar extends Component {
       >
         {showHeader && (
           <HeaderComponent
-            selected={selected}
+            selected={validSelection}
             shouldAnimate={Boolean(shouldHeaderAnimate && display !== 'years')}
             layout={layout}
             theme={theme}
@@ -390,7 +405,7 @@ export default class Calendar extends Component {
               theme={theme}
               today={today}
               rowHeight={rowHeight}
-              selected={selected}
+              selected={validSelection}
               scrollDate={scrollDate}
               showOverlay={showOverlay}
               width={width}
@@ -410,7 +425,7 @@ export default class Calendar extends Component {
               min={this._min}
               minDate={this._minDate}
               scrollToDate={this.scrollToDate}
-              selected={selected}
+              selected={validSelection}
               setDisplay={this.setDisplay}
               showMonths={showMonthsForYears}
               theme={theme}

--- a/src/Calendar/index.js
+++ b/src/Calendar/index.js
@@ -6,7 +6,7 @@ import {
   emptyFn,
   range,
   ScrollSpeed,
-  getValidSelectedRange,
+  getValidSelection,
 } from '../utils';
 import { defaultProps } from 'recompose';
 import defaultDisplayOptions from '../utils/defaultDisplayOptions';
@@ -333,7 +333,7 @@ export default class Calendar extends Component {
     const locale = this.getLocale();
     const theme = this.getTheme();
     const today = (this.today = startOfDay(new Date()));
-    const validSelection = getValidSelectedRange(
+    const validSelection = getValidSelection(
       selected,
       minDate || min,
       maxDate || max

--- a/src/MonthList/index.js
+++ b/src/MonthList/index.js
@@ -25,7 +25,10 @@ export default class MonthList extends Component {
     onScroll: PropTypes.func,
     overscanMonthCount: PropTypes.number,
     rowHeight: PropTypes.number,
-    selectedDate: PropTypes.instanceOf(Date),
+    selected: PropTypes.oneOfType([
+      PropTypes.instanceOf(Date),
+      PropTypes.object,
+    ]),
     showOverlay: PropTypes.bool,
     theme: PropTypes.object,
     today: PropTypes.instanceOf(Date),

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -205,7 +205,7 @@ export function isRange(date) {
   return start !== undefined && end !== undefined;
 }
 
-export function getValidSelectedRange(selected, minDate, maxDate) {
+export function getValidSelection(selected, minDate, maxDate) {
   if (!isRange(selected)) {
     if (minDate && isBefore(selected, minDate)) {
       return format(minDate, 'YYYY-MM-DD');

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -6,7 +6,7 @@ import isBefore from 'date-fns/is_before';
 import isSameDay from 'date-fns/is_same_day';
 import endOfDay from 'date-fns/end_of_day';
 import startOfDay from 'date-fns/start_of_day';
-import parse from 'date-fns/parse';
+import format from 'date-fns/format';
 import { withPropsOnChange } from 'recompose';
 
 export const keyCodes = {
@@ -203,6 +203,27 @@ export function isRange(date) {
   }
   const { start, end } = date;
   return start !== undefined && end !== undefined;
+}
+
+export function getValidSelectedRange(selected, minDate, maxDate) {
+  if (!isRange(selected)) {
+    if (minDate && isBefore(selected, minDate)) {
+      return format(minDate, 'YYYY-MM-DD');
+    }
+    if (maxDate && isAfter(selected, maxDate)) {
+      return format(maxDate, 'YYYY-MM-DD');
+    }
+    return selected;
+  }
+
+  let { start, end } = selected;
+  if (minDate && isBefore(start, minDate)) {
+    start = format(minDate, 'YYYY-MM-DD');
+  }
+  if (maxDate && isAfter(end, maxDate)) {
+    end = format(maxDate, 'YYYY-MM-DD');
+  }
+  return { start, end };
 }
 
 export function getSortedDate(start, end) {


### PR DESCRIPTION
**Changed:**
- Disable hover selection of dates/months that are out of valid range, defined by min/max dates.

**Preview:**

- before

<img width="279" alt="before" src="https://user-images.githubusercontent.com/7456154/73809271-af3ce600-480d-11ea-9552-179303ea4034.png">

- after

<img width="279" alt="after" src="https://user-images.githubusercontent.com/7456154/73809279-b49a3080-480d-11ea-959f-3069374da4e3.png">
