### PR TITLE
fix: get hovered date by standard format

### DIFF
--- a/src/Quarters/index.js
+++ b/src/Quarters/index.js
@@ -135,7 +135,7 @@ const Quarters = (props) => {
                       return (
                         <li
                           key={index}
-                          data-month={`${format(date, 'yyyy-MM')}`}
+                          data-month={`${format(date, 'yyyy-MM-dd')}`}
                           className={classNames({
                             [styles.selected]:
                               isSameMonth(date, start) ||

--- a/src/Years/index.js
+++ b/src/Years/index.js
@@ -148,12 +148,12 @@ const Years = ({
                     ? ''
                     : `Set date to ${format(date, 'MMMM do, yyyy')}`
                 }
-                data-month={`${format(date, 'yyyy-MM')}`}
+                data-month={`${format(date, 'yyyy-MM-dd')}`}
                 {...handlers}
               >
                 <div
                   className={styles.selection}
-                  data-month={`${format(date, 'yyyy-MM')}`}
+                  data-month={`${format(date, 'yyyy-MM-dd')}`}
                 >
                   {format(date, 'MMM', { locale: locale?.locale })}
                 </div>


### PR DESCRIPTION
To fix the hovering issue in month range picker.

Expected:

![image](https://github.com/appannie/react-infinite-calendar/assets/1772355/c27753dc-b0a0-4d79-83de-4b2a69a604d1)

Actual:
![image](https://github.com/appannie/react-infinite-calendar/assets/1772355/ab437121-b811-494c-8702-4663eb6dd2fc)
